### PR TITLE
Fix console spam after reload

### DIFF
--- a/src/lib/simMessages.ts
+++ b/src/lib/simMessages.ts
@@ -18,4 +18,5 @@ export default class Messages {
     static CYCLE_UPDATE = "cycle_update";
     static WORKER_DONE = "worker_done";
     static CONSOLE = "console";
+    static MSG_QUEUE_END = "msg_queue_end";
 };

--- a/src/lib/simWorker.ts
+++ b/src/lib/simWorker.ts
@@ -124,6 +124,9 @@ export default class SimWorker
                 case Messages.CLR_ALL_BREAKS:
                     this.breakPoints.clear();
                     break;
+                case Messages.MSG_QUEUE_END:
+                    self.postMessage({ type: Messages.MSG_QUEUE_END });
+                    break;
             }
         };
     }

--- a/src/logic/simulator/simMessages.ts
+++ b/src/logic/simulator/simMessages.ts
@@ -18,4 +18,5 @@ export default class Messages {
     static CYCLE_UPDATE = "cycle_update";
     static WORKER_DONE = "worker_done";
     static CONSOLE = "console";
+    static MSG_QUEUE_END = "msg_queue_end";
 };

--- a/src/presentation/Menu.svelte
+++ b/src/presentation/Menu.svelte
@@ -114,6 +114,7 @@
     // Reload: Load code into memory, set PC to start of program, restore Processor Status Register to defaults, set clock-enable
     function reloadClick(){
         if(globalThis.simulator){
+            globalThis.simulator.clearMessageQueue()
             globalThis.simulator.reloadProgram()
             reloadOverride.set([true,true])
         }
@@ -122,6 +123,7 @@
     // Reinitialize: Set all of memory to zeroes except for operating system code
     function reinitializeClick(){
         if(globalThis.simulator){
+            globalThis.simulator.clearMessageQueue()
             globalThis.simulator.resetMemory()
             reloadOverride.set([true,false])
         }
@@ -130,6 +132,7 @@
     // Randomize: Randomize all of memory except for operating system code
     function randomizeClick(){
         if(globalThis.simulator){
+            globalThis.simulator.clearMessageQueue()
             globalThis.simulator.randomizeMemory()
             reloadOverride.set([true,false])
         }


### PR DESCRIPTION
Fix console output continuing after reload in some cases.

Messages sent to and from the sim worker are queued. If the worker sends messages faster than the main thread can handle them, this queue naturally starts to build up. As there doesn't appear to be a way to clear existing messages, we simply tell the worker to append a `MSG_QUEUE_END` message and ignore any `CONSOLE` messages until we handle said `MSG_QUEUE_END` message.

This functionality wasn't added to the `PAUSE` button as there may be cases where all pending output is desired.