### PR TITLE
Prevent dangling simulators

### DIFF
--- a/src/logic/simulator/simulator.ts
+++ b/src/logic/simulator/simulator.ts
@@ -205,6 +205,13 @@ export default class Simulator
         this.ignoreConsoleMessages = true
         this.simWorker.postMessage({ type: Messages.MSG_QUEUE_END });
     }
+    
+    /**
+     * Terminate the simWorker and clean up other resources
+     */
+    public destroy() {
+        this.simWorker.terminate();
+    }
 
     /**
      * Load code into memory, set PC to start of program, restore Processor

--- a/src/presentation/EditorView.svelte
+++ b/src/presentation/EditorView.svelte
@@ -148,6 +148,10 @@
 			if(obj){
 				// Create globally-available Simulator class
 				let map = obj.pop()
+				// Clean up existing simulator
+				if (globalThis.simulator) {
+					globalThis.simulator.destroy();
+				}
 				globalThis.simulator = new Simulator(obj[0], map, getExtension())
 				globalThis.lastPtr = null
 				globalThis.lastBps = null


### PR DESCRIPTION
The "Assemble" button doesn't check whether or not a simulator has already been instantiated and simply creates a new simulator which spawns a new web worker, leaving the old ones dangling. This simply deletes the old simulator (which cleans up the worker) before a new one is created.