### PR TITLE
Adding support for form feed (screen clear) to the console.

### DIFF
--- a/src/logic/assembler/parser.ts
+++ b/src/logic/assembler/parser.ts
@@ -37,6 +37,7 @@ export default class Parser
         ['\\', '\\'.charCodeAt(0)],
         ['\'', '\''.charCodeAt(0)],
         ['\"', '\"'.charCodeAt(0)],
+        ['f', '\f'.charCodeAt(0)],
         ['n', '\n'.charCodeAt(0)],
         ['r', '\r'.charCodeAt(0)],
         ['t', '\t'.charCodeAt(0)]

--- a/src/presentation/ui.js
+++ b/src/presentation/ui.js
@@ -8,7 +8,7 @@
  *      - StepControls.svelte
  */
 
-import { activeStoplight, consoleSelected, UIReady, updateMainButton } from "./stores"
+import { activeStoplight, consoleSelected, UIReady, updateMainButton } from "./stores";
 
 // Signal that UI is ready to update
 function update(){
@@ -22,8 +22,15 @@ function printConsole(msg){
 }
 
 
-// Append to Console with given string
+// Append to Console with given string. If string contains a form feed ('\f', xC)
+// then we clear the console and append the remainder of the output
 function appendConsole(msg){
+    let lastFormFeed = msg.lastIndexOf('\f');
+    if (lastFormFeed > 0) {
+        clearConsole();
+        msg = msg.substring(lastFormFeed+1);
+    } 
+
     if(msg)
         modifyConsole(msg, true)
 }


### PR DESCRIPTION
Now supports form feed (`'\n'`, `xC`, `#12`) in the console as well as in parsed string literals.